### PR TITLE
Build package as header-only project

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from bincrafters import build_template_default
+from bincrafters import build_template_header_only
 
 if __name__ == "__main__":
-    builder = build_template_default.get_builder()
+    builder = build_template_header_only.get_builder()
     builder.run()

--- a/conanfile.py
+++ b/conanfile.py
@@ -16,6 +16,7 @@ class sqlite_ormConan(ConanFile):
     exports = ["LICENSE.md"]
     requires = "sqlite3/3.21.0@bincrafters/stable"
     source_subfolder = "source_subfolder"
+    no_copy_source = True
 
     def source(self):
         source_url = "https://github.com/fnc12/sqlite_orm"


### PR DESCRIPTION
- Some new features focused on header-only were integrated on Conan,
  no_copy_source prevents to create a build folder.

Signed-off-by: Uilian Ries <uilian@khomp.com>